### PR TITLE
Added optional authenticator parameter which enables us to use social logins like Google or Facebook.

### DIFF
--- a/lib/src/cognito_credentials.dart
+++ b/lib/src/cognito_credentials.dart
@@ -25,13 +25,13 @@ class CognitoCredentials {
   }
 
   /// Get AWS Credentials for authenticated user
-  Future<void> getAwsCredentials(token) async {
+  Future<void> getAwsCredentials(token, [String authenticator]) async {
     if (expireTime == null ||
         new DateTime.now().millisecondsSinceEpoch > expireTime - 60000) {
       final identityId = new CognitoIdentityId(_identityPoolId, _pool);
-      final identityIdId = await identityId.getIdentityId(token);
+      final identityIdId = await identityId.getIdentityId(token, authenticator);
 
-      final authenticator = 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
+      authenticator ??= 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
       final Map<String, String> loginParam = {
         authenticator: token,
       };

--- a/lib/src/cognito_identity_id.dart
+++ b/lib/src/cognito_identity_id.dart
@@ -18,14 +18,14 @@ class CognitoIdentityId {
   }
 
   /// Get AWS Identity Id for authenticated user
-  Future<String> getIdentityId(token) async {
+  Future<String> getIdentityId(token, [String authenticator]) async {
     final identityIdKey = 'aws.cognito.identity-id.$_identityPoolId';
     String identityId = await _pool.storage.getItem(identityIdKey);
     if (identityId != null) {
       this.identityId = identityId;
       return identityId;
     }
-    final authenticator = 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
+    authenticator ??= 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
     final Map<String, String> loginParam = {
       authenticator: token,
     };


### PR DESCRIPTION
Rather than logging in with a Cognito User we want to be able to also login with Google or Facebook.

This can be achieved by logging in with a registered federated identity provider like Google:

```dart
    final GoogleSignIn googleSignIn = GoogleSignIn(scopes: ['email']);
    final GoogleSignInAccount googleUser = await googleSignIn.signIn();
    GoogleSignInAuthentication googleAuth = await googleUser.authentication;
```

Then using the providers identity token to get the Cognito credentials:

```dart
    final userPool = new CognitoUserPool('ap-southeast-2_xxxxxxxxx', 'xxxxxxxxxxxxxxxxxxxxxxxxxx');
    final credentials = new CognitoCredentials('ap-southeast-2:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', userPool);
    await credentials.getAwsCredentials(googleAuth.idToken, 'accounts.google.com');
```

Note that `getAwsCredentials` now allows to specify the authenticator as an optional parameter like `'accounts.google.com'`.

And now we can make all our requests as usual:

```dart
      const endpoint = 'https://xxxxxxxxxx.execute-api.ap-southeast-2.amazonaws.com/default';
      final awsSigV4Client = new AwsSigV4Client(credentials.accessKeyId, credentials.secretAccessKey, endpoint, sessionToken: credentials.sessionToken, region: 'ap-southeast-2');
      final signedRequest = new SigV4Request(awsSigV4Client,
          method: 'POST',
          path: '/flutter',
          headers: new Map<String, String>.from({'header-1': 'one', 'header-2': 'two'}),
          queryParams: new Map<String, String>.from({'tracking': 'x123'}),
          body: new Map<String, dynamic>.from({'color': 'blue'}));
      http.Response response;
      response = await http.post(signedRequest.url, headers: signedRequest.headers, body: signedRequest.body);
```

This was requested [here too](https://github.com/jonsaw/amazon-cognito-identity-dart/issues/19)