### PR TITLE
Fixed canonical string signature mismatch on POST method to AWS API Gateway.

### DIFF
--- a/lib/sig_v4.dart
+++ b/lib/sig_v4.dart
@@ -9,7 +9,7 @@ const _x_amz_date = 'x-amz-date';
 const _x_amz_security_token = 'x-amz-security-token';
 const _host = 'host';
 const _authorization = 'Authorization';
-const _default_content_type = 'application/json';
+const _default_content_type = 'application/json; charset=utf-8';
 const _default_accept_type = 'application/json';
 
 class AwsSigV4Client {


### PR DESCRIPTION
Making a `POST` request to AWS API Gateway fails with `The request signature we calculated does not match the signature you provided.`

Details can be found [here](https://github.com/jonsaw/amazon-cognito-identity-dart/issues/35).

This PR fixes this.