### PR TITLE
Return session on CognitoUserNewPasswordRequiredException

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -623,7 +623,8 @@ class CognitoUser {
 
       throw new CognitoUserNewPasswordRequiredException(
           userAttributes: userAttributes,
-          requiredAttributes: requiredAttributes);
+          requiredAttributes: requiredAttributes,
+          session: _session);
     }
     return _authenticateUserInternal(dataAuthenticate, authenticationHelper);
   }

--- a/lib/src/cognito_user_exceptions.dart
+++ b/lib/src/cognito_user_exceptions.dart
@@ -18,10 +18,12 @@ class CognitoUserNewPasswordRequiredException extends CognitoUserException {
   String message;
   dynamic userAttributes;
   List<dynamic> requiredAttributes;
+  String session;
   CognitoUserNewPasswordRequiredException(
       {this.userAttributes,
       this.requiredAttributes,
-      this.message = 'New Password required'});
+      this.message = 'New Password required',
+      this.session});
 }
 
 class CognitoUserMfaRequiredException extends CognitoUserException {


### PR DESCRIPTION
Because we need session when responding to auth challenge
```dart
final Map<String, dynamic> params = {
        'ChallengeName': 'NEW_PASSWORD_REQUIRED',
        'ChallengeResponses': challengeResponses,
        'ClientId': userPool.getClientId(),
        'Session': session, <<<--
 };
userPool.client.request('RespondToAuthChallenge', params);
```