### PR TITLE
Expose IdentityIdId in cognito_credentials to upload to S3 user folder

### DIFF
--- a/lib/src/cognito_credentials.dart
+++ b/lib/src/cognito_credentials.dart
@@ -15,6 +15,7 @@ class CognitoCredentials {
   String secretAccessKey;
   String sessionToken;
   int expireTime;
+  String userIdentityId;
   CognitoCredentials(String identityPoolId, CognitoUserPool pool,
       {String region, String userPoolId}) {
     _pool = pool;
@@ -29,14 +30,14 @@ class CognitoCredentials {
     if (expireTime == null ||
         new DateTime.now().millisecondsSinceEpoch > expireTime - 60000) {
       final identityId = new CognitoIdentityId(_identityPoolId, _pool);
-      final identityIdId = await identityId.getIdentityId(token);
+      userIdentityId = await identityId.getIdentityId(token);
 
       final authenticator = 'cognito-idp.$_region.amazonaws.com/$_userPoolId';
       final Map<String, String> loginParam = {
         authenticator: token,
       };
       final Map<String, dynamic> paramsReq = {
-        'IdentityId': identityIdId,
+        'IdentityId': userIdentityId,
         'Logins': loginParam,
       };
 


### PR DESCRIPTION
Exposes the identity ID for the individual user so that we can upload to a specific users "folder" in S3. Also, changed the (formerly local) variable name from identityIdId to userIdentityId.

I updated the docs to show this use case since there are a few pitfalls I faced doing this e.g. assuming the ${cognito-identity.amazonaws.com:sub} policy parameter referred to the sub in the JWT token. Hopefully this save people some time.