### PR TITLE
Fixed the bug that made DEVICE_PASSWORD_VERIFIER for remembered device fail

### DIFF
--- a/lib/src/authentication_helper.dart
+++ b/lib/src/authentication_helper.dart
@@ -118,10 +118,10 @@ class AuthenticationHelper {
   }
 
   /// Generate salts and compute verifier.
-  void generateHashDevice(String deviceGroupKey, String username) {
+  void generateHashDevice(String deviceGroupKey, String deviceKey) {
     _randomPassword = this.generateRandomString();
     final String combinedString =
-        '`$deviceGroupKey$username:${this._randomPassword}';
+        '$deviceGroupKey$deviceKey:${this._randomPassword}';
     final String hashedString = this.hash(utf8.encode(combinedString));
 
     final String hexRandom = new RandomString().generate(length: 16);


### PR DESCRIPTION
If you have enabled [device remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) feature in you User Pool, this SDK will fail in response to `DEVICE_PASSWORD_VERIFIER` challenge, which occurs on the **second** time you login with the same device. Here is the error response from AWS:

```plain
HTTP/1.1 400 Bad Request
x-amzn-ErrorType: NotAuthorizedException:
x-amzn-ErrorMessage: Incorrect username or password.

{
  "__type": "NotAuthorizedException",
  "message": "Incorrect username or password."
}
```

This is because when you first time login with this device, it sends the WRONG `PasswordVerifier` JSON parameter in the `AWSCognitoIdentityProviderService.ConfirmDevice` request. This doesn't fail, which means you will be able to login the first time, but it is sending a WRONG parameter (hash based of the combination of device key, device group key and a random string), so AWS Cognito remembers the WRONG information. Consequently, the second time when the SDK sends a parameter `PASSWORD_CLAIM_SIGNATURE` in the `DEVICE_PASSWORD_VERIFIER` phase using the CORRECT device key and device group key to generate that hash, hence the conflict.

More details from [my blog](http://tsuinte.ru/2019/flutter_log_2_cognito/#2-Device-authentication-failure) if anyone is interested.