### PR TITLE
Added client secret support that is missing since original JS SDK

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -14,10 +14,11 @@ class Client {
     String region,
     String service = 'AWSCognitoIdentityProviderService',
     http.Client client,
+    String userAgent = 'aws-amplify/0.0.x dart',
   }) {
     this._region = region;
     this._service = service;
-    this._userAgent = 'aws-amplify/0.0.x dart';
+    this._userAgent = userAgent;
     this.endpoint = endpoint ?? 'https://cognito-idp.$_region.amazonaws.com/';
     this._client = client;
     if (this._client == null) {


### PR DESCRIPTION
What are in this PR:

1. Client secret support, see [my blog](http://tsuinte.ru/2019/flutter_log_2_cognito/#1-Client-secret-support) for more details. Maybe there are other requests that need this `SECRET_HASH` parameters, I just tested a few flows like sign up/login/password reset
2. Allow setting a custom user agent in the request