### PR TITLE
fixes salt to be a fixed length unsigned hex valueto avoid BigInt par…

### DIFF
--- a/lib/src/authentication_helper.dart
+++ b/lib/src/authentication_helper.dart
@@ -217,4 +217,30 @@ class AuthenticationHelper {
     }
     return hashStr;
   }
+
+  /// Converts a signed and possibly unpadded salt of 128 bits to unsigned and padded
+  String toUnsignedHex(String input) {
+    String output;
+    bool negative = false;
+    /// Detect negative and remove from string
+    if(input[0] == '-') {
+      negative = true;
+      output = input.substring(1); // remove negative sign
+    }
+    else {
+      output = input;
+    }
+    /// Pad string to 32 hex digits (128 bits total)
+    while(output.length < 32) {
+      output = '0' + output;
+    }
+    /// OR in a 1 to the top bit if the original string was negative
+    if(negative) {
+      String toReplace = output[0];
+      output = output.substring(1);
+      String updatedLeadingDigit = (int.parse(toReplace) | 0x8).toRadixString(16);
+      output = updatedLeadingDigit + output;
+    }
+    return output;
+  }
 }

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -347,7 +347,8 @@ class CognitoUser {
     final data = await client.request('RespondToAuthChallenge', params);
     final challengeParameters = data['ChallengeParameters'];
     final serverBValue = BigInt.parse(challengeParameters['SRP_B'], radix: 16);
-    final salt = BigInt.parse(challengeParameters['SALT'], radix: 16);
+    final saltString = authenticationHelper.toUnsignedHex(challengeParameters['SALT']);
+    final salt = BigInt.parse(saltString, radix: 16);
 
     final hkdf = authenticationHelper.getPasswordAuthenticationKey(
         _deviceKey, _randomPassword, serverBValue, salt);
@@ -499,6 +500,7 @@ class CognitoUser {
     );
     final dateHelper = new DateHelper();
     BigInt serverBValue;
+    String saltString;
     BigInt salt;
 
     Map<String, String> authParameters = {};
@@ -530,7 +532,8 @@ class CognitoUser {
 
     this.username = challengeParameters['USER_ID_FOR_SRP'];
     serverBValue = BigInt.parse(challengeParameters['SRP_B'], radix: 16);
-    salt = BigInt.parse(challengeParameters['SALT'], radix: 16);
+    saltString = authenticationHelper.toUnsignedHex(challengeParameters['SALT']);
+    salt = BigInt.parse(saltString, radix: 16);
     getCachedDeviceKeyAndPassword();
 
     var hkdf = authenticationHelper.getPasswordAuthenticationKey(


### PR DESCRIPTION
…sing errors

I was getting this error before this commit:

I/flutter (14876): FormatException: Invalid hexadecimal code unit U+002d. (at offset 1)
I/flutter (14876): An unknown error occurred

The salt value that was coming back from Cognito had a negative sign in front of it (U+002d corresponds to the '-' character) and the BigInt.parse() function was failing to account for that. This change should detect the negative sign, strip it, and add the binary 1 in the top bit position to the first hex digit.